### PR TITLE
Update manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,8 @@
     "tabs",
     "storage",
     "unlimitedStorage",
-    "webRequest"
+    "webRequest",
+    "clipboardWrite"
   ],
   "host_permissions": [
     "*://*/*"


### PR DESCRIPTION
Added     "clipboardWrite" to the permissions. 
Without this setting I wasn't able to have the command line copied into the clipboard by clicking "cmd".
I injected the changed manifest.json into the xpi and installed it, afterwards it worked.

