### PR TITLE
panel.js: use strict single quotes for the URL

### DIFF
--- a/panel/panel.js
+++ b/panel/panel.js
@@ -128,7 +128,7 @@ clear.addEventListener('click', async function() {
 async function createCommand(json, key_string) {
     const metadata = JSON.parse(json);
     const header_string = Object.entries(metadata.headers).map(([key, value]) => `-H "${key}: ${value.replace(/"/g, "'")}"`).join(' ');
-    return `${await SettingsManager.getExecutableName()} "${metadata.url}" ${header_string} ${key_string} ${await SettingsManager.getUseShakaPackager() ? "--use-shaka-packager " : ""}-M format=mkv`;
+    return `${await SettingsManager.getExecutableName()} '${metadata.url}' ${header_string} ${key_string} ${await SettingsManager.getUseShakaPackager() ? "--use-shaka-packager " : ""}-M format=mkv`;
 }
 
 async function appendLog(result) {


### PR DESCRIPTION
Otherwise, if the URL contains e.g. the dollar sign, it can lead to funny shell expansions.