### PR TITLE
Ensure MediaKeySession is defined

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -57,7 +57,7 @@
         proxy(EventTarget.prototype, 'addEventListener', (target, thisArg, args) => {
             const [type, listener] = args;
 
-            if (thisArg == null || !(thisArg instanceof MediaKeySession) || typeof MediaKeyMessageEvent === 'undefined' || type !== "message" || !listener) {
+            if (thisArg == null || typeof MediaKeySession === 'undefined' || !(thisArg instanceof MediaKeySession) || typeof MediaKeyMessageEvent === 'undefined' || type !== "message" || !listener) {
                 return target.apply(thisArg, args);
             }
 


### PR DESCRIPTION
Basically the same as #17, but at a different place for another WebAPI interface `MediaKeySession `. 

Make sure to check the existence of the interface before using it, otherwise it causes error and sometimes breaks the normal functionality of the webpage itself.

It's a regression introduced by 32be27f9d25a1f22677fda810f88daed19ac42cd.

And yes, I found it out via TP-Link admin page again (this time it broke it entirely at login page.)