### PR TITLE
Fix for `metadata.url` characters breaking command output for bash

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -287,6 +287,15 @@ export class SettingsManager {
         return result["use_shaka"] ?? true;
     }
 
+    static async saveUseSingleQuotes(use_single_quotes) {
+        await AsyncSyncStorage.setStorage({ use_single_quotes, });
+    }
+
+    static async getUseSingleQuotes() {
+        const result = await AsyncSyncStorage.getStorage(["use_single_quotes"]);
+        return result["use_single_quotes"] ?? false;
+    }
+
     static async saveExecutableName(exe_name) {
         await AsyncSyncStorage.setStorage({ exe_name: exe_name });
     }

--- a/panel/panel.html
+++ b/panel/panel.html
@@ -57,6 +57,8 @@
             <legend>Command options</legend>
             <input type="checkbox" id="use-shaka">
             <label for="use-shaka"> Use Shaka Packager</label><br>
+            <input type="checkbox" id="use-single-quotes">
+            <label for="use-single-quotes"> Use single quotes (preferred for bash)</label><br>
             <label for="downloader-name">Executable name: </label>
             <input type="text" class="text-box" id="downloader-name"><br>
             <label for="downloader-args">Additional arguments: </label>

--- a/panel/panel.js
+++ b/panel/panel.js
@@ -123,6 +123,11 @@ use_shaka.addEventListener('change', async function (){
     await SettingsManager.saveUseShakaPackager(use_shaka.checked);
 });
 
+const use_single_quotes = document.getElementById('use-single-quotes');
+use_single_quotes.addEventListener('change', async function (){
+    await SettingsManager.saveUseSingleQuotes(use_single_quotes.checked);
+});
+
 const downloader_name = document.getElementById('downloader-name');
 downloader_name.addEventListener('input', async function (){
     await SettingsManager.saveExecutableName(downloader_name.value);
@@ -143,11 +148,20 @@ clear.addEventListener('click', async function() {
 
 async function createCommand(json, key_string) {
     const metadata = JSON.parse(json);
-    const headerString = Object.entries(metadata.headers).map(([key, value]) => `-H '${key}: ${value.replace(/'/g, '"')}'`).join(' ');
+
+    // Based on user choice in the panel, we have the quote character that should be used in the command,
+    // and a safe quote character that can be used to format the header values.
+    const useSingleQuotes = await SettingsManager.getUseSingleQuotes();
+    const quoteChar = useSingleQuotes ? "'" : '"';
+    const safeQuoteChar = useSingleQuotes ? '"' : "'";
+    const headerString = Object.entries(metadata.headers).map(
+        ([key, value]) => `-H ${quoteChar}${key}: ${value.replaceAll(quoteChar, safeQuoteChar)}${quoteChar}`
+    ).join(' ');
+
     const executableName = await SettingsManager.getExecutableName();
     const useShaka = await SettingsManager.getUseShakaPackager();
     const additionalArgs = await SettingsManager.getAdditionalArguments();
-    return `${executableName} '${metadata.url}' ${headerString} ${key_string} ${useShaka ? "--use-shaka-packager " : ""}${additionalArgs}`;
+    return `${executableName} ${quoteChar}${metadata.url}${quoteChar} ${headerString} ${key_string} ${useShaka ? "--use-shaka-packager " : ""}${additionalArgs}`;
 }
 
 async function appendLog(result) {
@@ -249,6 +263,7 @@ document.addEventListener('DOMContentLoaded', async function () {
     enabled.checked = await SettingsManager.getEnabled();
     SettingsManager.setDarkMode(await SettingsManager.getDarkMode());
     use_shaka.checked = await SettingsManager.getUseShakaPackager();
+    use_single_quotes.checked = await SettingsManager.getUseSingleQuotes();
     downloader_name.value = await SettingsManager.getExecutableName();
     downloader_args.value = await SettingsManager.getAdditionalArguments();
     SettingsManager.setSelectedDeviceType(await SettingsManager.getSelectedDeviceType());

--- a/panel/panel.js
+++ b/panel/panel.js
@@ -143,11 +143,11 @@ clear.addEventListener('click', async function() {
 
 async function createCommand(json, key_string) {
     const metadata = JSON.parse(json);
-    const headerString = Object.entries(metadata.headers).map(([key, value]) => `-H "${key}: ${value.replace(/"/g, "'")}"`).join(' ');
+    const headerString = Object.entries(metadata.headers).map(([key, value]) => `-H '${key}: ${value.replace(/'/g, '"')}'`).join(' ');
     const executableName = await SettingsManager.getExecutableName();
     const useShaka = await SettingsManager.getUseShakaPackager();
     const additionalArgs = await SettingsManager.getAdditionalArguments();
-    return `${executableName} "${metadata.url}" ${headerString} ${key_string} ${useShaka ? "--use-shaka-packager " : ""}${additionalArgs}`;
+    return `${executableName} '${metadata.url}' ${headerString} ${key_string} ${useShaka ? "--use-shaka-packager " : ""}${additionalArgs}`;
 }
 
 async function appendLog(result) {


### PR DESCRIPTION
As explained in #59, when the `metadata.url` contains invalid characters that prevent bash from executing the command correctly. Namely characters like `$` that try to expand interpolate a variable in the URL.

This PR modifies the `createCommand()` function to use single quotes when formatting the command instead of double quotes. The single quotes will allow bash to parse the entire URL correctly as one argument.

I've tested this fix against the exact scenario in #59 and it resolves the issue for me, without any negative affects.

---------------------------------------------

I didn't see any contribution guidelines in the repo, so let me know if there's anything you'd like me to provide in this PR :+1: 


EDIT: Realized it was actually the `$` characters causing the problem. Silly me.